### PR TITLE
Upgrade node-abort-controller to 1.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 lib
 es
 yarn-error.log
+.idea

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
-    "node-abort-controller": "^1.1.0"
+    "node-abort-controller": "^1.2.1"
   }
 }

--- a/src/AbortError.ts
+++ b/src/AbortError.ts
@@ -1,3 +1,5 @@
+import {AbortSignal} from 'node-abort-controller';
+
 /**
  * Thrown when an abortable function was aborted.
  *

--- a/src/abortable.ts
+++ b/src/abortable.ts
@@ -1,3 +1,4 @@
+import {AbortSignal} from 'node-abort-controller';
 import {execute} from './execute';
 
 /**

--- a/src/all.test.ts
+++ b/src/all.test.ts
@@ -1,4 +1,4 @@
-import AbortController from 'node-abort-controller';
+import AbortController, {AbortSignal} from 'node-abort-controller';
 import defer = require('defer-promise');
 import {AbortError} from './AbortError';
 import {all} from './all';

--- a/src/all.ts
+++ b/src/all.ts
@@ -1,4 +1,4 @@
-import AbortController from 'node-abort-controller';
+import AbortController, {AbortSignal} from 'node-abort-controller';
 import {AbortError, isAbortError} from './AbortError';
 
 /**
@@ -16,9 +16,9 @@ import {AbortError, isAbortError} from './AbortError';
  * The promises returned from `executor` must be abortable, i.e. once
  * `innerSignal` is aborted, they must reject with `AbortError` either
  * immediately, or after doing any async cleanup.
- * 
+ *
  * Example:
- * 
+ *
  *     const [result1, result2] = await all(signal, signal => [
  *       makeRequest(signal, params1),
  *       makeRequest(signal, params2),

--- a/src/delay.ts
+++ b/src/delay.ts
@@ -1,4 +1,5 @@
 import {execute} from './execute';
+import {AbortSignal} from 'node-abort-controller';
 
 /**
  * Returns a promise that fulfills after delay and rejects with

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -1,4 +1,5 @@
 import {AbortError} from './AbortError';
+import {AbortSignal} from 'node-abort-controller';
 
 /**
  * Similar to `new Promise(executor)`, but allows executor to return abort

--- a/src/forever.ts
+++ b/src/forever.ts
@@ -1,3 +1,4 @@
+import {AbortSignal} from 'node-abort-controller';
 import {execute} from './execute';
 
 /**

--- a/src/race.test.ts
+++ b/src/race.test.ts
@@ -1,4 +1,4 @@
-import AbortController from 'node-abort-controller';
+import AbortController, {AbortSignal} from 'node-abort-controller';
 import defer = require('defer-promise');
 import {AbortError} from './AbortError';
 import {race} from './race';

--- a/src/race.ts
+++ b/src/race.ts
@@ -1,4 +1,4 @@
-import AbortController from 'node-abort-controller';
+import AbortController, {AbortSignal} from 'node-abort-controller';
 import {AbortError, isAbortError} from './AbortError';
 
 /**

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -1,3 +1,4 @@
+import {AbortSignal} from 'node-abort-controller';
 import {delay} from './delay';
 import {rethrowAbortError} from './AbortError';
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,4 +1,4 @@
-import AbortController from 'node-abort-controller';
+import AbortController, {AbortSignal} from 'node-abort-controller';
 import {catchAbortError} from './AbortError';
 
 /**

--- a/src/spawn.test.ts
+++ b/src/spawn.test.ts
@@ -1,4 +1,4 @@
-import AbortController from 'node-abort-controller';
+import AbortController, {AbortSignal} from 'node-abort-controller';
 import {spawn} from './spawn';
 import {forever} from './forever';
 import {delay} from './delay';

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -1,4 +1,4 @@
-import AbortController from 'node-abort-controller';
+import AbortController, {AbortSignal} from 'node-abort-controller';
 import {AbortError, catchAbortError, isAbortError} from './AbortError';
 
 export type SpawnEffects = {

--- a/src/waitForEvent.test.ts
+++ b/src/waitForEvent.test.ts
@@ -11,7 +11,7 @@ test('external abort', async () => {
   const eventTarget = new AbortController().signal;
   eventTarget.removeEventListener = jest.fn(eventTarget.removeEventListener);
 
-  let result: PromiseSettledResult<Event> | undefined;
+  let result: PromiseSettledResult<any> | undefined;
 
   waitForEvent(signal, eventTarget, 'test').then(
     value => {
@@ -48,7 +48,7 @@ test('fulfill', async () => {
   const eventTarget = eventTargetController.signal;
   eventTarget.removeEventListener = jest.fn(eventTarget.removeEventListener);
 
-  let result: PromiseSettledResult<Event> | undefined;
+  let result: PromiseSettledResult<any> | undefined;
 
   waitForEvent(signal, eventTarget, 'abort').then(
     value => {

--- a/src/waitForEvent.ts
+++ b/src/waitForEvent.ts
@@ -1,3 +1,4 @@
+import {AbortSignal} from 'node-abort-controller';
 import {execute} from './execute';
 
 export type EventTargetLike<T> =

--- a/yarn.lock
+++ b/yarn.lock
@@ -2677,10 +2677,10 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-abort-controller@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-1.1.0.tgz#8a734a631b022af29963be7245c1483cbb9e070d"
-  integrity sha512-dEYmUqjtbivotqjraOe8UvhT/poFfog1BQRNsZm/MSEDDESk2cQ1tvD8kGyuN07TM/zoW+n42odL8zTeJupYdQ==
+node-abort-controller@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-1.2.1.tgz#1eddb57eb8fea734198b11b28857596dc6165708"
+  integrity sha512-79PYeJuj6S9+yOHirR0JBLFOgjB6sQCir10uN6xRx25iD+ZD4ULqgRn3MwWBRaQGB0vEgReJzWwJo42T1R6YbQ==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Minor release of node-abort-controller has breaking changes in typings, so downstream projects are affected.

This PR updates node-abort-controller to the latest 1.2.0 version.