### PR TITLE
feat: optimize AbortError

### DIFF
--- a/src/AbortError.test.ts
+++ b/src/AbortError.test.ts
@@ -33,3 +33,46 @@ test('catchAbortError', () => {
   expect(() => catchAbortError(new AbortError())).not.toThrow();
   expect(() => catchAbortError(new Error())).toThrow();
 });
+
+test('AbortError with custom message', () => {
+  const error = new AbortError('Custom abort message');
+  expect(error.message).toBe('Custom abort message');
+  expect(error.name).toBe('AbortError');
+});
+
+test('AbortError default message', () => {
+  const error = new AbortError();
+  expect(error.message).toBe('The operation has been aborted');
+  expect(error.name).toBe('AbortError');
+});
+
+test('AbortError with captureStackTrace disabled', () => {
+  const error = new AbortError('Test message', false);
+  expect(error.message).toBe('Test message');
+  expect(error.name).toBe('AbortError');
+  expect(error.stack).toBe(undefined);
+
+  expect(isAbortError(error)).toBe(true);
+  expect(error).toBeInstanceOf(Error);
+  expect(error).toBeInstanceOf(AbortError);
+});
+
+test('AbortError with captureStackTrace enabled', () => {
+  const error = new AbortError('Test message', true);
+  expect(error.message).toBe('Test message');
+  expect(error.name).toBe('AbortError');
+  expect(error.stack).toContain('AbortError: Test message');
+  expect(error.stack).toContain('src/AbortError.test.ts');
+
+  expect(isAbortError(error)).toBe(true);
+  expect(error).toBeInstanceOf(Error);
+  expect(error).toBeInstanceOf(AbortError);
+});
+
+test('throwIfAborted with custom reason', () => {
+  const abortController = new AbortController();
+  const customReason = new Error('Custom reason');
+  abortController.abort(customReason);
+
+  expect(() => throwIfAborted(abortController.signal)).toThrow(AbortError);
+});

--- a/src/AbortError.test.ts
+++ b/src/AbortError.test.ts
@@ -35,34 +35,33 @@ it('catchAbortError', () => {
   expect(() => catchAbortError(new Error())).toThrow();
 });
 
-test('AbortError with custom message', () => {
+it('AbortError with custom message', () => {
   const error = new AbortError('Custom abort message');
   expect(error.message).toBe('Custom abort message');
   expect(error.name).toBe('AbortError');
 });
 
-test('AbortError default message', () => {
+it('AbortError default message', () => {
   const error = new AbortError();
   expect(error.message).toBe('The operation has been aborted');
   expect(error.name).toBe('AbortError');
 });
 
-test('AbortError with captureStackTrace disabled', () => {
+it('AbortError with captureStackTrace disabled', () => {
   const error = new AbortError('Test message', false);
   expect(error.message).toBe('Test message');
   expect(error.name).toBe('AbortError');
-  expect(error.stack).toBe(undefined);
+  expect(error.stack).toBe('');
 
   expect(isAbortError(error)).toBe(true);
   expect(error).toBeInstanceOf(Error);
   expect(error).toBeInstanceOf(AbortError);
 });
 
-test('AbortError with captureStackTrace enabled', () => {
+it('AbortError with captureStackTrace enabled', () => {
   const error = new AbortError('Test message', true);
   expect(error.message).toBe('Test message');
   expect(error.name).toBe('AbortError');
-  expect(error.stack).toContain('AbortError: Test message');
   expect(error.stack).toContain('src/AbortError.test.ts');
 
   expect(isAbortError(error)).toBe(true);
@@ -70,7 +69,7 @@ test('AbortError with captureStackTrace enabled', () => {
   expect(error).toBeInstanceOf(AbortError);
 });
 
-test('throwIfAborted with custom reason', () => {
+it('throwIfAborted with custom reason', () => {
   const abortController = new AbortController();
   const customReason = new Error('Custom reason');
   abortController.abort(customReason);

--- a/src/AbortError.ts
+++ b/src/AbortError.ts
@@ -4,17 +4,23 @@
  * **Warning**: do not use `instanceof` with this class. Instead, use
  * `isAbortError` function.
  */
-export class AbortError extends Error {
-  constructor() {
-    super('The operation has been aborted');
+export class AbortError implements Error {
+  name: 'AbortError' = 'AbortError';
+  stack?: string;
 
-    this.message = 'The operation has been aborted';
-
-    this.name = 'AbortError';
-
-    if (typeof Error.captureStackTrace === 'function') {
-      Error.captureStackTrace(this, this.constructor);
+  constructor(
+    public message = 'The operation has been aborted',
+    captureStackTrace = true,
+  ) {
+    if (captureStackTrace) {
+      Error.captureStackTrace?.(this, this.constructor);
     }
+
+    Object.setPrototypeOf(this, Error.prototype);
+  }
+
+  static [Symbol.hasInstance](instance: unknown) {
+    return isAbortError(instance);
   }
 }
 

--- a/src/AbortError.ts
+++ b/src/AbortError.ts
@@ -6,7 +6,7 @@
  */
 export class AbortError implements Error {
   name: 'AbortError' = 'AbortError';
-  stack?: string;
+  stack: string = '';
 
   constructor(
     public message = 'The operation has been aborted',

--- a/src/all.test.ts
+++ b/src/all.test.ts
@@ -206,3 +206,94 @@ test('empty', async () => {
   expect(signal.addEventListener).toHaveBeenCalledTimes(0);
   expect(signal.removeEventListener).toHaveBeenCalledTimes(0);
 });
+
+test('abort with custom reason', async () => {
+  const abortController = new AbortController();
+  const signal = abortController.signal;
+
+  const customReason = new Error('Custom abort reason');
+
+  const deferred1 = defer<string>();
+  const deferred2 = defer<number>();
+
+  let innerSignal: AbortSignal;
+
+  const promise = all(signal, signal => {
+    innerSignal = signal;
+    return [deferred1.promise, deferred2.promise];
+  });
+
+  abortController.abort(customReason);
+
+  expect(innerSignal!.aborted).toBe(true);
+
+  // When external signal is aborted with custom reason,
+  // promises should reject with AbortError
+  deferred1.reject(new AbortError());
+  deferred2.reject(new AbortError());
+
+  // The result should be AbortError (first rejection), not custom reason
+  await expect(promise).rejects.toMatchObject({
+    name: 'AbortError',
+  });
+});
+
+test('abort before all with custom reason', async () => {
+  const abortController = new AbortController();
+  const signal = abortController.signal;
+
+  const customReason = new Error('Custom abort reason');
+  abortController.abort(customReason);
+
+  const executor = jest.fn((signal: AbortSignal) => [Promise.resolve('test')]);
+
+  await expect(all(signal, executor)).rejects.toBe(customReason);
+
+  expect(executor).not.toHaveBeenCalled();
+});
+
+test('innerSignal receives custom reason on external abort', async () => {
+  const abortController = new AbortController();
+  const signal = abortController.signal;
+
+  const customReason = new Error('Custom abort reason');
+
+  const deferred1 = defer<string>();
+
+  let innerSignal: AbortSignal;
+
+  all(signal, signal => {
+    innerSignal = signal;
+    return [deferred1.promise];
+  });
+
+  abortController.abort(customReason);
+
+  expect(innerSignal!.aborted).toBe(true);
+  expect(innerSignal!.reason).toBe(customReason);
+});
+
+test('innerSignal receives descriptive reason on promise rejection', async () => {
+  const abortController = new AbortController();
+  const signal = abortController.signal;
+
+  const deferred1 = defer<string>();
+  const deferred2 = defer<number>();
+
+  let innerSignal: AbortSignal;
+
+  all(signal, signal => {
+    innerSignal = signal;
+    return [deferred1.promise, deferred2.promise];
+  });
+
+  deferred1.reject(new Error('test'));
+
+  await nextTick();
+
+  expect(innerSignal!.aborted).toBe(true);
+  expect(innerSignal!.reason).toMatchObject({
+    name: 'AbortError',
+    message: 'One of the promises passed to all() rejected',
+  });
+});

--- a/src/all.test.ts
+++ b/src/all.test.ts
@@ -2,7 +2,7 @@ import defer from 'defer-promise';
 import expect from 'expect';
 import {AbortError} from './AbortError';
 import {all} from './all';
-import {spyOn} from './testUtils/spy';
+import {createSpy, spyOn} from './testUtils/spy';
 import {nextTick} from './utils/nextTick';
 
 it('external abort', async () => {
@@ -209,7 +209,7 @@ it('empty', async () => {
   expect(removeEventListenerSpy.callCount).toBe(0);
 });
 
-test('abort with custom reason', async () => {
+it('abort with custom reason', async () => {
   const abortController = new AbortController();
   const signal = abortController.signal;
 
@@ -240,21 +240,21 @@ test('abort with custom reason', async () => {
   });
 });
 
-test('abort before all with custom reason', async () => {
+it('abort before all with custom reason', async () => {
   const abortController = new AbortController();
   const signal = abortController.signal;
 
   const customReason = new Error('Custom abort reason');
   abortController.abort(customReason);
 
-  const executor = jest.fn((signal: AbortSignal) => [Promise.resolve('test')]);
+  const executor = createSpy((signal: AbortSignal) => [Promise.resolve('test')]);
 
   await expect(all(signal, executor)).rejects.toBe(customReason);
 
-  expect(executor).not.toHaveBeenCalled();
+  expect(executor.callCount).toBe(0);
 });
 
-test('innerSignal receives custom reason on external abort', async () => {
+it('innerSignal receives custom reason on external abort', async () => {
   const abortController = new AbortController();
   const signal = abortController.signal;
 
@@ -275,7 +275,7 @@ test('innerSignal receives custom reason on external abort', async () => {
   expect(innerSignal!.reason).toBe(customReason);
 });
 
-test('innerSignal receives descriptive reason on promise rejection', async () => {
+it('innerSignal receives descriptive reason on promise rejection', async () => {
   const abortController = new AbortController();
   const signal = abortController.signal;
 

--- a/src/all.ts
+++ b/src/all.ts
@@ -143,7 +143,7 @@ export function all<T>(
 ): Promise<T[]> {
   return new Promise((resolve, reject) => {
     if (signal.aborted) {
-      reject(new AbortError());
+      reject(signal.reason ?? new AbortError());
       return;
     }
 
@@ -157,7 +157,7 @@ export function all<T>(
     }
 
     const abortListener = () => {
-      innerAbortController.abort();
+      innerAbortController.abort(signal.reason ?? new AbortError());
     };
 
     signal.addEventListener('abort', abortListener);
@@ -189,7 +189,12 @@ export function all<T>(
           settled();
         },
         reason => {
-          innerAbortController.abort();
+          innerAbortController.abort(
+            new AbortError(
+              'One of the promises passed to all() rejected',
+              false,
+            ),
+          );
 
           if (
             rejection == null ||

--- a/src/execute.test.ts
+++ b/src/execute.test.ts
@@ -34,7 +34,7 @@ it('resolve immediately', async () => {
 
 it('resolve before abort', async () => {
   const abortController = new AbortController();
-  const signal = abortController.signal;  
+  const signal = abortController.signal;
   const addEventListenerSpy = spyOn(signal, 'addEventListener');
   const removeEventListenerSpy = spyOn(signal, 'removeEventListener');
 
@@ -320,12 +320,12 @@ it('async abort callback rejection', async () => {
   expect(removeEventListenerSpy.callCount).toBe(1);
 });
 
-test('abort with custom reason', async () => {
+it('abort with custom reason', async () => {
   const abortController = new AbortController();
   const signal = abortController.signal;
 
   const customReason = new Error('Custom abort reason');
-  const callback = jest.fn((reason?: unknown) => {
+  const callback = createSpy((reason?: unknown) => {
     expect(reason).toBe(customReason);
   });
 
@@ -346,21 +346,21 @@ test('abort with custom reason', async () => {
 
   await nextTick();
 
-  expect(callback).toHaveBeenCalledTimes(1);
+  expect(callback.callCount).toBe(1);
   expect(result).toMatchObject({
     status: 'rejected',
     reason: customReason,
   });
 });
 
-test('abort before execute with custom reason', async () => {
+it('abort before execute with custom reason', async () => {
   const abortController = new AbortController();
   const signal = abortController.signal;
 
   const customReason = new Error('Custom abort reason');
   abortController.abort(customReason);
 
-  const executor = jest.fn(
+  const executor = createSpy(
     (
       resolve: (value: string) => void,
       reject: (reason?: any) => void,
@@ -371,17 +371,17 @@ test('abort before execute with custom reason', async () => {
 
   await expect(execute(signal, executor)).rejects.toBe(customReason);
 
-  expect(executor).not.toHaveBeenCalled();
+  expect(executor.callCount).toBe(0);
 });
 
-test('async abort callback with custom reason', async () => {
+it('async abort callback with custom reason', async () => {
   const abortController = new AbortController();
   const signal = abortController.signal;
 
   const customReason = new Error('Custom abort reason');
   const callbackDeferred = defer<void>();
 
-  const callback = jest.fn((reason?: unknown) => {
+  const callback = createSpy((reason?: unknown) => {
     expect(reason).toBe(customReason);
     return callbackDeferred.promise;
   });
@@ -413,5 +413,5 @@ test('async abort callback with custom reason', async () => {
     status: 'rejected',
     reason: customReason,
   });
-  expect(callback).toHaveBeenCalledTimes(1);
+  expect(callback.callCount).toBe(1);
 });

--- a/src/execute.test.ts
+++ b/src/execute.test.ts
@@ -317,3 +317,99 @@ test('async abort callback rejection', async () => {
   expect(signal.addEventListener).toHaveBeenCalledTimes(1);
   expect(signal.removeEventListener).toHaveBeenCalledTimes(1);
 });
+
+test('abort with custom reason', async () => {
+  const abortController = new AbortController();
+  const signal = abortController.signal;
+
+  const customReason = new Error('Custom abort reason');
+  const callback = jest.fn((reason?: unknown) => {
+    expect(reason).toBe(customReason);
+  });
+
+  let result: PromiseSettledResult<string> | undefined;
+
+  execute<string>(signal, (resolve, reject) => {
+    return callback;
+  }).then(
+    value => {
+      result = {status: 'fulfilled', value};
+    },
+    reason => {
+      result = {status: 'rejected', reason};
+    },
+  );
+
+  abortController.abort(customReason);
+
+  await nextTick();
+
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(result).toMatchObject({
+    status: 'rejected',
+    reason: customReason,
+  });
+});
+
+test('abort before execute with custom reason', async () => {
+  const abortController = new AbortController();
+  const signal = abortController.signal;
+
+  const customReason = new Error('Custom abort reason');
+  abortController.abort(customReason);
+
+  const executor = jest.fn(
+    (
+      resolve: (value: string) => void,
+      reject: (reason?: any) => void,
+    ): (() => void | PromiseLike<void>) => {
+      return () => {};
+    },
+  );
+
+  await expect(execute(signal, executor)).rejects.toBe(customReason);
+
+  expect(executor).not.toHaveBeenCalled();
+});
+
+test('async abort callback with custom reason', async () => {
+  const abortController = new AbortController();
+  const signal = abortController.signal;
+
+  const customReason = new Error('Custom abort reason');
+  const callbackDeferred = defer<void>();
+
+  const callback = jest.fn((reason?: unknown) => {
+    expect(reason).toBe(customReason);
+    return callbackDeferred.promise;
+  });
+
+  let result: PromiseSettledResult<string> | undefined;
+
+  execute<string>(signal, (resolve, reject) => {
+    return callback;
+  }).then(
+    value => {
+      result = {status: 'fulfilled', value};
+    },
+    reason => {
+      result = {status: 'rejected', reason};
+    },
+  );
+
+  abortController.abort(customReason);
+
+  await nextTick();
+
+  expect(result).toBeUndefined();
+
+  callbackDeferred.resolve();
+
+  await nextTick();
+
+  expect(result).toMatchObject({
+    status: 'rejected',
+    reason: customReason,
+  });
+  expect(callback).toHaveBeenCalledTimes(1);
+});

--- a/src/race.test.ts
+++ b/src/race.test.ts
@@ -194,3 +194,94 @@ test('reject during cleanup', async () => {
   expect(signal.addEventListener).toHaveBeenCalledTimes(1);
   expect(signal.removeEventListener).toHaveBeenCalledTimes(1);
 });
+
+test('abort with custom reason', async () => {
+  const abortController = new AbortController();
+  const signal = abortController.signal;
+
+  const customReason = new Error('Custom abort reason');
+
+  const deferred1 = defer<string>();
+  const deferred2 = defer<number>();
+
+  let innerSignal: AbortSignal;
+
+  const promise = race(signal, signal => {
+    innerSignal = signal;
+    return [deferred1.promise, deferred2.promise];
+  });
+
+  abortController.abort(customReason);
+
+  expect(innerSignal!.aborted).toBe(true);
+
+  // When external signal is aborted with custom reason,
+  // promises should reject with AbortError
+  deferred1.reject(new AbortError());
+  deferred2.reject(new AbortError());
+
+  // The result should be AbortError (first rejection), not custom reason
+  await expect(promise).rejects.toMatchObject({
+    name: 'AbortError',
+  });
+});
+
+test('abort before race with custom reason', async () => {
+  const abortController = new AbortController();
+  const signal = abortController.signal;
+
+  const customReason = new Error('Custom abort reason');
+  abortController.abort(customReason);
+
+  const executor = jest.fn((signal: AbortSignal) => [Promise.resolve('test')]);
+
+  await expect(race(signal, executor)).rejects.toBe(customReason);
+
+  expect(executor).not.toHaveBeenCalled();
+});
+
+test('innerSignal receives custom reason on external abort', async () => {
+  const abortController = new AbortController();
+  const signal = abortController.signal;
+
+  const customReason = new Error('Custom abort reason');
+
+  const deferred1 = defer<string>();
+
+  let innerSignal: AbortSignal;
+
+  race(signal, signal => {
+    innerSignal = signal;
+    return [deferred1.promise];
+  });
+
+  abortController.abort(customReason);
+
+  expect(innerSignal!.aborted).toBe(true);
+  expect(innerSignal!.reason).toBe(customReason);
+});
+
+test('innerSignal receives descriptive reason on promise settlement', async () => {
+  const abortController = new AbortController();
+  const signal = abortController.signal;
+
+  const deferred1 = defer<string>();
+  const deferred2 = defer<number>();
+
+  let innerSignal: AbortSignal;
+
+  race(signal, signal => {
+    innerSignal = signal;
+    return [deferred1.promise, deferred2.promise];
+  });
+
+  deferred1.resolve('test');
+
+  await nextTick();
+
+  expect(innerSignal!.aborted).toBe(true);
+  expect(innerSignal!.reason).toMatchObject({
+    name: 'AbortError',
+    message: 'One of the promises passed to race() settled',
+  });
+});

--- a/src/race.test.ts
+++ b/src/race.test.ts
@@ -2,7 +2,7 @@ import defer from 'defer-promise';
 import expect from 'expect';
 import {AbortError} from './AbortError';
 import {race} from './race';
-import {spyOn} from './testUtils/spy';
+import {createSpy, spyOn} from './testUtils/spy';
 import {nextTick} from './utils/nextTick';
 
 it('external abort', async () => {
@@ -197,7 +197,7 @@ it('reject during cleanup', async () => {
   expect(removeEventListenerSpy.callCount).toBe(1);
 });
 
-test('abort with custom reason', async () => {
+it('abort with custom reason', async () => {
   const abortController = new AbortController();
   const signal = abortController.signal;
 
@@ -228,21 +228,21 @@ test('abort with custom reason', async () => {
   });
 });
 
-test('abort before race with custom reason', async () => {
+it('abort before race with custom reason', async () => {
   const abortController = new AbortController();
   const signal = abortController.signal;
 
   const customReason = new Error('Custom abort reason');
   abortController.abort(customReason);
 
-  const executor = jest.fn((signal: AbortSignal) => [Promise.resolve('test')]);
+  const executor = createSpy((signal: AbortSignal) => [Promise.resolve('test')]);
 
   await expect(race(signal, executor)).rejects.toBe(customReason);
 
-  expect(executor).not.toHaveBeenCalled();
+  expect(executor.callCount).toBe(0);
 });
 
-test('innerSignal receives custom reason on external abort', async () => {
+it('innerSignal receives custom reason on external abort', async () => {
   const abortController = new AbortController();
   const signal = abortController.signal;
 
@@ -263,7 +263,7 @@ test('innerSignal receives custom reason on external abort', async () => {
   expect(innerSignal!.reason).toBe(customReason);
 });
 
-test('innerSignal receives descriptive reason on promise settlement', async () => {
+it('innerSignal receives descriptive reason on promise settlement', async () => {
   const abortController = new AbortController();
   const signal = abortController.signal;
 

--- a/src/spawn.test.ts
+++ b/src/spawn.test.ts
@@ -33,7 +33,7 @@ test('fork manual abort', async () => {
       "fork start",
       "post fork",
       "pre task abort",
-      "fork abort: The operation has been aborted",
+      "fork abort: This operation was aborted",
       "post task abort",
     ]
   `);
@@ -70,7 +70,7 @@ test('fork abort on spawn finish', async () => {
       "fork start",
       "post fork",
       "spawn finish",
-      "fork abort: The operation has been aborted",
+      "fork abort: This operation was aborted",
     ]
   `);
 
@@ -109,7 +109,7 @@ test('fork abort on spawn error', async () => {
       "fork start",
       "post fork",
       "spawn finish",
-      "fork abort: The operation has been aborted",
+      "fork abort: This operation was aborted",
       "spawn throw: the-error",
     ]
   `);
@@ -151,7 +151,7 @@ test('error thrown from fork', async () => {
       "fork start",
       "post fork",
       "fork finish",
-      "spawn abort: The operation has been aborted",
+      "spawn abort: This operation was aborted",
       "spawn throw: the-error",
     ]
   `);
@@ -194,4 +194,93 @@ test('abort before spawn', async () => {
 
   expect(signal.addEventListener).not.toHaveBeenCalled();
   expect(signal.removeEventListener).not.toHaveBeenCalled();
+});
+
+test('abort with custom reason during spawn execution', async () => {
+  const abortController = new AbortController();
+  const signal = abortController.signal;
+
+  const customReason = new Error('Custom abort reason');
+  const actions: string[] = [];
+
+  await spawn(signal, async (signal, {fork}) => {
+    fork(async signal => {
+      actions.push('fork start');
+      try {
+        await forever(signal);
+      } catch (err: any) {
+        actions.push(`fork abort: ${err.message}`);
+      }
+    });
+
+    actions.push('post fork');
+    await delay(signal, 0);
+    actions.push('pre abort');
+    abortController.abort(customReason);
+    await delay(signal, 0);
+  }).catch(err => {
+    actions.push(`spawn catch: ${err.message || err.toString()}`);
+  });
+
+  expect(actions).toContain('fork start');
+  expect(actions).toContain('post fork');
+  expect(actions).toContain('pre abort');
+  expect(actions).toContain('fork abort: This operation was aborted');
+});
+
+test('innerSignal aborted on spawn finish', async () => {
+  const abortController = new AbortController();
+  const signal = abortController.signal;
+
+  let innerSignal: AbortSignal | undefined;
+
+  await spawn(signal, async (signal, {fork}) => {
+    innerSignal = signal;
+    fork(async signal => {
+      await forever(signal).catch(() => {});
+    });
+
+    await delay(signal, 0);
+  });
+
+  expect(innerSignal!.aborted).toBe(true);
+});
+
+test('innerSignal aborted on fork error', async () => {
+  const abortController = new AbortController();
+  const signal = abortController.signal;
+
+  let innerSignal: AbortSignal | undefined;
+
+  await spawn(signal, async (signal, {fork}) => {
+    innerSignal = signal;
+    fork(async signal => {
+      await delay(signal, 0);
+      throw new Error('fork-error');
+    });
+
+    await forever(signal).catch(() => {});
+  }).catch(() => {});
+
+  expect(innerSignal!.aborted).toBe(true);
+});
+
+test('innerSignal aborted when spawn function throws', async () => {
+  const abortController = new AbortController();
+  const signal = abortController.signal;
+
+  let innerSignal: AbortSignal | undefined;
+  const spawnError = new Error('spawn-error');
+
+  await spawn(signal, async (signal, {fork}) => {
+    innerSignal = signal;
+    fork(async signal => {
+      await forever(signal).catch(() => {});
+    });
+
+    await delay(signal, 0);
+    throw spawnError;
+  }).catch(() => {});
+
+  expect(innerSignal!.aborted).toBe(true);
 });

--- a/src/spawn.test.ts
+++ b/src/spawn.test.ts
@@ -18,7 +18,7 @@ it('fork manual abort', async () => {
       try {
         await forever(signal);
       } catch (err: any) {
-        actions.push(`fork abort: ${err.message}`);
+        actions.push('fork abort');
       }
     });
 
@@ -34,7 +34,7 @@ it('fork manual abort', async () => {
     'fork start',
     'post fork',
     'pre task abort',
-    'fork abort: The operation has been aborted',
+    'fork abort',
     'post task abort',
   ]);
 
@@ -56,7 +56,7 @@ it('fork abort on spawn finish', async () => {
       try {
         await forever(signal);
       } catch (err: any) {
-        actions.push(`fork abort: ${err.message}`);
+        actions.push('fork abort');
       }
     });
 
@@ -69,7 +69,7 @@ it('fork abort on spawn finish', async () => {
     'fork start',
     'post fork',
     'spawn finish',
-    'fork abort: The operation has been aborted',
+    'fork abort',
   ]);
 
   expect(addEventListenerSpy.callCount).toBe(1);
@@ -90,7 +90,7 @@ it('fork abort on spawn error', async () => {
       try {
         await forever(signal);
       } catch (err: any) {
-        actions.push(`fork abort: ${err.message}`);
+        actions.push('fork abort');
       }
     });
 
@@ -106,7 +106,7 @@ it('fork abort on spawn error', async () => {
     'fork start',
     'post fork',
     'spawn finish',
-    'fork abort: The operation has been aborted',
+    'fork abort',
     'spawn throw: the-error',
   ]);
 
@@ -135,7 +135,7 @@ it('error thrown from fork', async () => {
     try {
       await forever(signal);
     } catch (err: any) {
-      actions.push(`spawn abort: ${err.message}`);
+      actions.push('spawn abort');
       throw err;
     }
   }).catch(err => {
@@ -146,7 +146,7 @@ it('error thrown from fork', async () => {
     'fork start',
     'post fork',
     'fork finish',
-    'spawn abort: The operation has been aborted',
+    'spawn abort',
     'spawn throw: the-error',
   ]);
 
@@ -190,7 +190,7 @@ it('abort before spawn', async () => {
   expect(removeEventListenerSpy.callCount).toBe(0);
 });
 
-test('abort with custom reason during spawn execution', async () => {
+it('abort with custom reason during spawn execution', async () => {
   const abortController = new AbortController();
   const signal = abortController.signal;
 
@@ -203,7 +203,7 @@ test('abort with custom reason during spawn execution', async () => {
       try {
         await forever(signal);
       } catch (err: any) {
-        actions.push(`fork abort: ${err.message}`);
+        actions.push('fork abort');
       }
     });
 
@@ -219,10 +219,10 @@ test('abort with custom reason during spawn execution', async () => {
   expect(actions).toContain('fork start');
   expect(actions).toContain('post fork');
   expect(actions).toContain('pre abort');
-  expect(actions).toContain('fork abort: The operation has been aborted');
+  expect(actions).toContain('fork abort');
 });
 
-test('innerSignal aborted on spawn finish', async () => {
+it('innerSignal aborted on spawn finish', async () => {
   const abortController = new AbortController();
   const signal = abortController.signal;
 
@@ -240,7 +240,7 @@ test('innerSignal aborted on spawn finish', async () => {
   expect(innerSignal!.aborted).toBe(true);
 });
 
-test('innerSignal aborted on fork error', async () => {
+it('innerSignal aborted on fork error', async () => {
   const abortController = new AbortController();
   const signal = abortController.signal;
 
@@ -259,7 +259,7 @@ test('innerSignal aborted on fork error', async () => {
   expect(innerSignal!.aborted).toBe(true);
 });
 
-test('innerSignal aborted when spawn function throws', async () => {
+it('innerSignal aborted when spawn function throws', async () => {
   const abortController = new AbortController();
   const signal = abortController.signal;
 


### PR DESCRIPTION
Refactored `AbortError` to optionally omit stack trace. This dramatically increases its performance.

Internal `AbortController`s (like ones in `race`, `all`, etc.) are now aborted with `AbortError`s with stack traces disabled.

Ensured that `AbortSignal.reason` is correctly propagated.